### PR TITLE
get-mumble_deps.sh: Allow spaces in vcpkg path

### DIFF
--- a/get-mumble_deps.sh
+++ b/get-mumble_deps.sh
@@ -66,15 +66,15 @@ case "$OSTYPE" in
     * ) echo "The OSTYPE is either not defined or unsupported. Aborting...";;
 esac
 
-if [ ! -d $VCPKGDIR ] 
+if [ ! -d "$VCPKGDIR" ] 
     then 
-        git clone https://github.com/mumble-voip/vcpkg.git $VCPKGDIR
+        git clone https://github.com/mumble-voip/vcpkg.git "$VCPKGDIR"
 fi
 
-if [ -d $VCPKGDIR ] 
+if [ -d "$VCPKGDIR" ] 
     then
-        cd $VCPKGDIR
-        if [ ! -x $VCPKGDIR/vcpkg ]
+        cd "$VCPKGDIR"
+        if [ ! -x "$VCPKGDIR"/vcpkg ]
             then
                 case "$OSTYPE" in
                     msys* ) ./bootstrap-vcpkg.bat -disableMetrics


### PR DESCRIPTION
This commit adds quotes around all places the VCPKGDIR variable is dereferenced in order for the code to not break if there are spaces in the path.